### PR TITLE
Only load the active platform's natives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 apply plugin: 'java'
 
 group = 'com.playsawdust.chipper'
@@ -9,27 +11,25 @@ repositories {
 	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
-
 def lwjgl(String... modules) {
-	def ver = '3.2.4-SNAPSHOT'
-	def platforms = [ 'linux', 'macos', 'windows' ]
-	
-	def rtrn = []
-	rtrn.add(dependencies.create("org.lwjgl:lwjgl:${ver}"))
-	modules.each { module ->
-		rtrn.add(dependencies.create("org.lwjgl:lwjgl-${module}:${ver}"))
-	}
-	platforms.each { platform ->
-		rtrn.add(dependencies.create("org.lwjgl:lwjgl:${ver}:natives-${platform}"))
-		modules.each { module ->
-			rtrn.add(dependencies.create("org.lwjgl:lwjgl-${module}:${ver}:natives-${platform}"))
-		}
-	}
-	return rtrn
+    def ver = '3.2.4-SNAPSHOT'
+    def platform = DefaultNativePlatform.currentOperatingSystem.toFamilyName()
+
+    def rtrn = []
+    rtrn.add(dependencies.create("org.lwjgl:lwjgl:${ver}"))
+    modules.each { module ->
+        rtrn.add(dependencies.create("org.lwjgl:lwjgl-${module}:${ver}"))
+    }
+
+    rtrn.add(dependencies.create("org.lwjgl:lwjgl:${ver}:natives-${platform}"))
+    modules.each { module ->
+        rtrn.add(dependencies.create("org.lwjgl:lwjgl-${module}:${ver}:natives-${platform}"))
+    }
+    return rtrn
 }
 
 dependencies {
-	//glow
+	// Glow
 	compile 'com.google.guava:guava:28.2-jre';
 	
 	compile lwjgl('glfw', 'openal', 'opengl', 'stb')


### PR DESCRIPTION
This will prevent 3 different sets of natives from being downloaded and imported every time the project is cloned.

Also, contact me on Discord, @falkreon. I'd like to chat, but I've left Cotton's guild. halotroop#2288